### PR TITLE
RGOPS 805 RG PHP SDK incompatible with PHP 5.6

### DIFF
--- a/src/GatewayChecksum.php
+++ b/src/GatewayChecksum.php
@@ -11,8 +11,8 @@ namespace RocketGate\Sdk;
 class GatewayChecksum
 {
     public static $checksum = "";
-    public static $baseChecksum = "09423cb8c2344b452ec3f162108a6965";
-    public static $versionNo = "P7.9";
+    public static $baseChecksum = "9c96ff767ca901ad4f922c8ae2d0c405";
+    public static $versionNo = "P8.0";
 
 //////////////////////////////////////////////////////////////////////
 //
@@ -30,7 +30,7 @@ class GatewayChecksum
             md5_file($dirName . "/GatewayCodes.php");
         GatewayChecksum::$checksum = md5($baseString);
         if (GatewayChecksum::$checksum != GatewayChecksum::$baseChecksum) {
-            GatewayChecksum::$versionNo = "P7.9m";
+            GatewayChecksum::$versionNo = "P8.0m";
         }
     }
 }

--- a/src/GatewayChecksum.php
+++ b/src/GatewayChecksum.php
@@ -12,7 +12,7 @@ class GatewayChecksum
 {
     public static $checksum = "";
     public static $baseChecksum = "9c96ff767ca901ad4f922c8ae2d0c405";
-    public static $versionNo = "P8.0";
+    public static $versionNo = "P7.10";
 
 //////////////////////////////////////////////////////////////////////
 //
@@ -30,7 +30,7 @@ class GatewayChecksum
             md5_file($dirName . "/GatewayCodes.php");
         GatewayChecksum::$checksum = md5($baseString);
         if (GatewayChecksum::$checksum != GatewayChecksum::$baseChecksum) {
-            GatewayChecksum::$versionNo = "P8.0m";
+            GatewayChecksum::$versionNo = "P7.10m";
         }
     }
 }

--- a/src/GatewayService.php
+++ b/src/GatewayService.php
@@ -866,7 +866,7 @@ class GatewayService
 //
 //////////////////////////////////////////////////////////////////////
 //
-    public function GetLatestResponseCode() : int
+    public function GetLatestResponseCode()
     {
         return $this->rocketGateLatestResponseCode;
     }
@@ -877,7 +877,7 @@ class GatewayService
 //
 //////////////////////////////////////////////////////////////////////
 //
-    public function GetLatestExecutionTime() : float
+    public function GetLatestExecutionTime()
     {
         return $this->rocketGateLatestExecutionTime;
     }
@@ -888,7 +888,7 @@ class GatewayService
 //
 //////////////////////////////////////////////////////////////////////
 //
-    function GetLatestConnectionTime() : float
+    function GetLatestConnectionTime()
     {
         return $this->rocketGateLatestConnectionTime;
     }


### PR DESCRIPTION
Remove data types for the following functions:

GetLatestResponseCode()
GetLatestExecutionTime()
GetLatestConnectionTime()