### PR TITLE
[Bugfix] php 8.1 str_replace with NULL deprecation

### DIFF
--- a/src/GatewayRequest.php
+++ b/src/GatewayRequest.php
@@ -74,7 +74,7 @@ class GatewayRequest extends GatewayParameterList
 //
         foreach ($this->params as $key => $value) {
             $xmlString .= "<" . $key . ">";// Add opening of element
-            $xmlString .= $this->TranslateXML($value);
+            $xmlString .= is_null($value) ? '' : $this->TranslateXML($value);
             $xmlString .= "</" . $key . ">";// Add closing of element
         }
 


### PR DESCRIPTION
There are instances where transformation to XML fails with `E_DEPRECATED: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated`

If a value is NULL in [this loop](https://github.com/rocketgate/rocketgate-php-sdk/compare/master...ppp0:do-not-call-str-replace-with-null?expand=1#diff-10c32c563e4f09f44b85c87758c5993f91c0d26ee9464ea28f31b87f028d81c5R75-R79), just skip calling `TranslateXML()`

